### PR TITLE
Implement Granular Ratelimiting

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -16,7 +16,6 @@ app.use("*", cors());
 // Apply default rate limiter to all API routes, specific routes will have their own rate limiters as needed
 app.use("/api/*", defaultRateLimiter);
 
-
 // Health check
 app.get("/health", (c) => {
   return c.json({ status: "ok", timestamp: new Date().toISOString() });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,6 +13,7 @@ const app = new Hono();
 // Middleware
 app.use("*", honoLogger());
 app.use("*", cors());
+// Apply default rate limiter to all API routes, specific routes will have their own rate limiters as needed
 app.use("/api/*", defaultRateLimiter);
 
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,7 +1,7 @@
 import { Hono } from "hono";
 import { cors } from "hono/cors";
 import { logger as honoLogger } from "hono/logger";
-import { rateLimiter } from "hono-rate-limiter";
+import { defaultRateLimiter } from "./middleware/ratelimiting";
 import { logger } from "./logger";
 import { usersRoutes } from "./routes/users";
 import { videosRoutes } from "./routes/videos";
@@ -13,14 +13,7 @@ const app = new Hono();
 // Middleware
 app.use("*", honoLogger());
 app.use("*", cors());
-app.use(
-  "/api/*",
-  rateLimiter({
-    windowMs: 60 * 1000, // 1 minute
-    limit: 50, // 100 requests per window
-    keyGenerator: (c) => c.req.header("x-forwarded-for") ?? "", // Use IP address as key
-  })
-);
+app.use("/api/*", defaultRateLimiter);
 
 
 // Health check

--- a/server/src/middleware/ratelimiting.ts
+++ b/server/src/middleware/ratelimiting.ts
@@ -1,37 +1,37 @@
 import { rateLimiter } from "hono-rate-limiter";
 import { getClientIp } from "../routes/users";
 
-// rate limiter for comment creation to prevent spam 
+// Rate limiter for comment creation to prevent spam
 export const commentWriteRateLimiter = rateLimiter({
-    windowMs: 60 * 1000, // 1 minute
-    limit: 3, // 3 comments per minute
-    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
+  windowMs: 60 * 1000, // 1 minute
+  limit: 3, // 3 comments per minute
+  keyGenerator: (c) => getClientIp(c.req.raw),
 });
 
 // Separate rate limiter for liking/unliking comments to prevent abuse of like system
 export const commentLikeRateLimiter = rateLimiter({
-    windowMs: 60 * 1000, // 1 minute
-    limit: 10, // 10 like/unlike actions per minute
-    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
+  windowMs: 60 * 1000, // 1 minute
+  limit: 10, // 10 like/unlike actions per minute
+  keyGenerator: (c) => getClientIp(c.req.raw),
 });
 
 // Separate rate limiter for liking videos to prevent abuse of like system
 export const videoLikeRateLimiter = rateLimiter({
-    windowMs: 60 * 1000, // 1 minute
-    limit: 15, // 15 like/unlike actions per minute
-    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
+  windowMs: 60 * 1000, // 1 minute
+  limit: 15, // 15 like/unlike actions per minute
+  keyGenerator: (c) => getClientIp(c.req.raw),
 });
 
 // Separate rate limiter for viewing videos to prevent abuse of view count
 export const videoViewRateLimiter = rateLimiter({
-    windowMs: 60 * 1000, // 1 minute
-    limit: 30, // 30 video views per minute
-    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
+  windowMs: 60 * 1000, // 1 minute
+  limit: 30, // 30 video views per minute
+  keyGenerator: (c) => getClientIp(c.req.raw),
 });
 
 // Default rate limiter for general API requests to prevent abuse
 export const defaultRateLimiter = rateLimiter({
-    windowMs: 60 * 1000, // 1 minute
-    limit: 50, // 50 requests per window
-    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
-  })
+  windowMs: 60 * 1000, // 1 minute
+  limit: 50, // 50 requests per window
+  keyGenerator: (c) => getClientIp(c.req.raw),
+});

--- a/server/src/middleware/ratelimiting.ts
+++ b/server/src/middleware/ratelimiting.ts
@@ -1,0 +1,37 @@
+import { rateLimiter } from "hono-rate-limiter";
+import { getClientIp } from "../routes/users";
+
+// rate limiter for comment creation to prevent spam 
+export const commentWriteRateLimiter = rateLimiter({
+    windowMs: 60 * 1000, // 1 minute
+    limit: 3, // 3 comments per minute
+    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
+});
+
+// Separate rate limiter for liking/unliking comments to prevent abuse of like system
+export const commentLikeRateLimiter = rateLimiter({
+    windowMs: 60 * 1000, // 1 minute
+    limit: 10, // 10 like/unlike actions per minute
+    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
+});
+
+// Separate rate limiter for liking videos to prevent abuse of like system
+export const videoLikeRateLimiter = rateLimiter({
+    windowMs: 60 * 1000, // 1 minute
+    limit: 15, // 15 like/unlike actions per minute
+    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
+});
+
+// Separate rate limiter for viewing videos to prevent abuse of view count
+export const videoViewRateLimiter = rateLimiter({
+    windowMs: 60 * 1000, // 1 minute
+    limit: 30, // 30 video views per minute
+    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
+});
+
+// Default rate limiter for general API requests to prevent abuse
+export const defaultRateLimiter = rateLimiter({
+    windowMs: 60 * 1000, // 1 minute
+    limit: 50, // 50 requests per window
+    keyGenerator: (c) => getClientIp(c.req.raw), // Use IP address as key
+  })

--- a/server/src/routes/comments.ts
+++ b/server/src/routes/comments.ts
@@ -4,6 +4,7 @@ import { db } from "../db";
 import { comments, commentLikes, users } from "../db/schema";
 import { getClientIp, getOrCreateUser } from "./users";
 import { recaptcha } from "../middleware/recaptcha";
+import { commentWriteRateLimiter, commentLikeRateLimiter } from "../middleware/ratelimiting";
 import { logger } from "../logger";
 
 export const commentsRoutes = new Hono();
@@ -111,7 +112,7 @@ commentsRoutes.get("/videos/:videoId/comments", async (c) => {
 });
 
 // POST /api/videos/:videoId/comments - create a comment
-commentsRoutes.post("/videos/:videoId/comments", recaptcha, async (c) => {
+commentsRoutes.post("/videos/:videoId/comments", commentWriteRateLimiter, recaptcha, async (c) => {
   const videoId = c.req.param("videoId");
   const ip = getClientIp(c.req.raw);
   const user = await getOrCreateUser(ip);
@@ -183,7 +184,7 @@ commentsRoutes.post("/videos/:videoId/comments", recaptcha, async (c) => {
 });
 
 // POST /api/comments/:commentId/like - like a comment
-commentsRoutes.post("/comments/:commentId/like", recaptcha, async (c) => {
+commentsRoutes.post("/comments/:commentId/like", commentLikeRateLimiter, recaptcha, async (c) => {
   const commentId = c.req.param("commentId");
   const ip = getClientIp(c.req.raw);
   const user = await getOrCreateUser(ip);

--- a/server/src/routes/videoLikes.ts
+++ b/server/src/routes/videoLikes.ts
@@ -4,6 +4,7 @@ import { db } from "../db";
 import { videos, videoLikes } from "../db/schema";
 import { getClientIp, getOrCreateUser } from "./users";
 import { recaptcha } from "../middleware/recaptcha";
+import { videoLikeRateLimiter } from "../middleware/ratelimiting";
 
 export const videoLikesRoutes = new Hono();
 
@@ -28,7 +29,7 @@ videoLikesRoutes.get("/videos/:videoId/like", async (c) => {
 });
 
 // POST /api/videos/:videoId/like - like a video
-videoLikesRoutes.post("/videos/:videoId/like", recaptcha, async (c) => {
+videoLikesRoutes.post("/videos/:videoId/like", videoLikeRateLimiter, recaptcha, async (c) => {
   const videoId = c.req.param("videoId");
   const ip = getClientIp(c.req.raw);
   const user = await getOrCreateUser(ip);

--- a/server/src/routes/videos.ts
+++ b/server/src/routes/videos.ts
@@ -3,6 +3,7 @@ import { desc, eq, sql } from "drizzle-orm";
 import { db } from "../db";
 import { videos } from "../db/schema";
 import { logger } from "../logger";
+import { videoViewRateLimiter } from "../middleware/ratelimiting";
 
 export const videosRoutes = new Hono();
 
@@ -13,7 +14,7 @@ videosRoutes.get("/videos", async (c) => {
 });
 
 // POST /api/videos/:id/view - increment view count
-videosRoutes.post("/videos/:id/view", async (c) => {
+videosRoutes.post("/videos/:id/view", videoViewRateLimiter, async (c) => {
   const videoId = c.req.param("id");
 
   const result = await db


### PR DESCRIPTION
Granular Rate Limiting

Replaces the single catch-all rate limiter with per-endpoint rate limiters tailored to each action type.

Changes

- New middleware (`middleware/ratelimiting.ts`) — defines separate rate limiters with limits appropriate to each action:
  - Comment creation: 3/min
  - Comment likes: 10/min
  - Video likes: 15/min
  - Video views: 30/min
  - Default (all /api/* routes): 50/min
- Route-level middleware — each write endpoint now applies its own rate limiter before the request handler, in addition to the existing global default.
- Removed inline rate limiter from index.ts in favour of the shared `defaultRateLimiter`, defined in `middleware/ratelimiting.ts`


Motivation

The previous setup applied a single 50 req/min limit across all API routes. This meant a user could exhaust their limit with normal browsing and then be unable to post comments, or conversely, spam comments without being throttled individually. Granular limits let each action be constrained independently based on expected usage patterns.